### PR TITLE
Fixed Dismissible : false issue

### DIFF
--- a/lib/src/slider.dart
+++ b/lib/src/slider.dart
@@ -137,7 +137,7 @@ class _SliderButtonState extends State<SliderButton> {
                     ),
                   )
                 : Dismissible(
-                    key: Key("cancel"),
+                    key: UniqueKey(),
                     direction: DismissDirection.startToEnd,
                     dismissThresholds: {DismissDirection.startToEnd: widget.dismissThresholds},
 


### PR DESCRIPTION
By using UniqueKey() instead of Key("cancel") we avoid keys duplication and a dismissed widget will no longer be in the widget tree.
With that tiny change, we can use dismissable: true without error.
Nice package btw